### PR TITLE
Update viewport after changing the page

### DIFF
--- a/src/View/PageViewBase.cpp
+++ b/src/View/PageViewBase.cpp
@@ -528,4 +528,5 @@ void PageViewBase::updateSceneRect()
     const QRectF brect(QPointF(x1, y1), QPointF(x2, y2));
     _DEBUG << "scene rect:" << brect;
     setSceneRect(brect);
+    viewport()->update();
 }


### PR DESCRIPTION
When some page is wider than other pages some part of it remains in the background until window update occurs. For example, switch to another window and back.

![Screenshot](https://cloud.githubusercontent.com/assets/3754317/12550029/f3bc3d80-c382-11e5-841a-07bb4cec16d2.jpg)