### PR TITLE
Dev/gaps continous view

### DIFF
--- a/src/ComicBookCfgDialog.cpp
+++ b/src/ComicBookCfgDialog.cpp
@@ -44,6 +44,7 @@ ComicBookCfgDialog::ComicBookCfgDialog(QWidget *parent, ComicBookSettings *cfg):
     cb_smallcursor->setChecked(cfg->smallCursor());
     cb_embedpagenumbers->setChecked(cfg->embedPageNumbers());
     cb_smoothscaling->setChecked(cfg->smoothScaling());
+    sb_gapsize->setValue(cfg->gapSize());
 
     sb_cachesize->setValue(cfg->cacheSize());
     cb_cacheadjust->setChecked(cfg->cacheAutoAdjust());
@@ -74,6 +75,7 @@ void ComicBookCfgDialog::accept()
 	cfg->embedPageNumbers(cb_embedpagenumbers->isChecked());
 	cfg->smoothScaling(cb_smoothscaling->isChecked());
 	cfg->infoFont(font);
+    cfg->gapSize(sb_gapsize->value());
 
 	//
 	// misc

--- a/src/ComicBookSettings.cpp
+++ b/src/ComicBookSettings.cpp
@@ -38,6 +38,7 @@
 #define OPT_EMBEDPAGENUMBERS         "/EmbedPageNumbers"
 #define OPT_CONTSCROLL               "/ContinuousScroll"
 #define OPT_VIEWTYPE                 "/ViewType"
+#define OPT_GAPSIZE                  "/GapSize"
 
 #define GRP_NAVI                     "/Navigation"
 
@@ -162,6 +163,11 @@ void ComicBookSettings::load()
 		}
 		m_contscroll = m_cfg->value(OPT_CONTSCROLL, true).toBool();
 		m_viewtype = convert(viewtype2string, m_cfg->value(OPT_VIEWTYPE, viewtype2string[0].str).toString());
+        m_gapsize = m_cfg->value(OPT_GAPSIZE, 3).toInt();
+        if (m_gapsize < 0)
+                {
+                    m_gapsize = 0;
+                }
 	m_cfg->endGroup();
 	m_cfg->beginGroup(GRP_RUNTIME);
 		m_lastdir = m_cfg->value(OPT_LASTDIR, QString()).toString();
@@ -260,6 +266,10 @@ int ComicBookSettings::cacheSize() const
     return m_cachesize;
 }
 
+int ComicBookSettings::gapSize() const
+{
+    return m_gapsize;
+}
 bool ComicBookSettings::cacheAutoAdjust() const
 {
     return m_cacheadjust;
@@ -450,6 +460,17 @@ void ComicBookSettings::cacheSize(int s)
             s = 1;
         }
         m_cfg->setValue(GRP_MISC OPT_CACHESIZE, m_cachesize = s);
+    }
+}
+void ComicBookSettings::gapSize(int s)
+{
+    if (s != m_gapsize)
+    {
+        if (s < 0)
+        {
+            s = 0;
+        }
+        m_cfg->setValue(GRP_VIEW OPT_GAPSIZE, m_gapsize = s);
     }
 }
 

--- a/src/ComicBookSettings.cpp
+++ b/src/ComicBookSettings.cpp
@@ -21,6 +21,7 @@
 #include <QTextStream>
 #include <QStandardPaths>
 #include <iostream>
+#include "ComicBookDebug.h"
 
 #define GRP_VIEW                     "/View"
 #define OPT_TWOPAGES                 "/TwoPages"
@@ -471,6 +472,8 @@ void ComicBookSettings::gapSize(int s)
             s = 0;
         }
         m_cfg->setValue(GRP_VIEW OPT_GAPSIZE, m_gapsize = s);
+        emit displaySettingsChanged(OPT_GAPSIZE);
+        _DEBUG << "Gap size"<< m_gapsize;
     }
 }
 

--- a/src/ComicBookSettings.h
+++ b/src/ComicBookSettings.h
@@ -51,6 +51,7 @@ namespace QComicBook
 			const QStringList& recentlyOpened() const;
 			QColor background() const;
 			int cacheSize() const;
+			int gapSize() const;
 			bool cacheAutoAdjust() const;
 			bool cacheThumbnails() const;
 			int thumbnailsAge() const;
@@ -81,6 +82,7 @@ namespace QComicBook
 			void recentlyOpened(const QStringList &hist);
 			void background(const QColor &color);
 			void cacheSize(int s);
+			void gapSize(int s);
 			void cacheAutoAdjust(bool f);
 			void cacheThumbnails(bool f);
 			void thumbnailsAge(int n);
@@ -127,6 +129,7 @@ namespace QComicBook
 			QColor m_bgcolor;
 			QStringList m_recent;
 			int m_cachesize;
+			int m_gapsize;
 			int m_thumbsage;
 			bool m_cacheadjust;
 			bool m_cachethumbs;

--- a/src/ComicMainWindow.cpp
+++ b/src/ComicMainWindow.cpp
@@ -1186,6 +1186,11 @@ void ComicMainWindow::reconfigureDisplay()
     view->setSmallCursor(cfg->smallCursor());
     view->showPageNumbers(cfg->embedPageNumbers());
     view->setBackground(cfg->background());
+    ContinuousPageView* cv = dynamic_cast<ContinuousPageView*>(view.data());
+    if(cv ) {
+        _DEBUG << "ContinuousPageView";
+        cv->setGapSize(cfg->gapSize());
+    }
 }
 
 void ComicMainWindow::printingFinished()

--- a/src/ComicMainWindow.cpp
+++ b/src/ComicMainWindow.cpp
@@ -1186,10 +1186,13 @@ void ComicMainWindow::reconfigureDisplay()
     view->setSmallCursor(cfg->smallCursor());
     view->showPageNumbers(cfg->embedPageNumbers());
     view->setBackground(cfg->background());
-    ContinuousPageView* cv = dynamic_cast<ContinuousPageView*>(view.data());
-    if(cv ) {
-        _DEBUG << "ContinuousPageView";
-        cv->setGapSize(cfg->gapSize());
+    if (cfg->viewType() == Continuous)
+    {
+        ContinuousPageView* cv = dynamic_cast<ContinuousPageView*>(view.data());
+        if(cv ) {
+            _DEBUG << "ContinuousPageView";
+            cv->setGapSize(cfg->gapSize());
+        }
     }
 }
 

--- a/src/ConfigDialog.ui
+++ b/src/ConfigDialog.ui
@@ -128,6 +128,46 @@
             </item>
            </layout>
           </item>
+           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3p">
+            <item>
+             <widget class="QLabel" name="label_4p">
+              <property name="text">
+               <string>Gap Size</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2p">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="sb_gapsize">
+              <property name="suffix">
+               <string>px</string>
+              </property>
+              <property name="prefix">
+               <string/>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>128</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/View/ContinuousPageView.cpp
+++ b/src/View/ContinuousPageView.cpp
@@ -309,7 +309,7 @@ void ContinuousPageView::recalculatePageSizes()
 		}
 		p->setPos(0, y);
                 center(p, true, false); // center horizontally only, preserve Y
-                _DEBUG << "page: " << i << ", y=" << y;
+                _DEBUG << "page: " << i << ", y=" << y << " gap="<<props.gapSize();
 		// update positions lookup
 		m_ypos.startCoordinate(i) = y;
 		m_ypos.endCoordinate(i) = y + p->estimatedSize().height();
@@ -521,4 +521,9 @@ int ContinuousPageView::currentPage() const
     }
     _DEBUG << "current page" << current;
     return current;
+}
+
+void ContinuousPageView::setGapSize(int f)
+{
+    props.setGapSize(f);
 }

--- a/src/View/ContinuousPageView.cpp
+++ b/src/View/ContinuousPageView.cpp
@@ -146,6 +146,7 @@ void ContinuousPageView::recreateComicPageImages()
 		_DEBUG << "creating ComicPageImage for one page" << i;
                 imgLabel.append(p);
                 scene->addItem(p);
+                // scene->addText( QString::number(i));
             }
         }
         
@@ -291,7 +292,7 @@ void ContinuousPageView::recalculatePageSizes()
                 ++n;
             }
         }
-        int y = 0;
+    int y = 0;
 	if (n > 0) //if we had at least one real size, calculate and set estimated sizes
 	{
 		avgw /= n;
@@ -312,7 +313,7 @@ void ContinuousPageView::recalculatePageSizes()
 		// update positions lookup
 		m_ypos.startCoordinate(i) = y;
 		m_ypos.endCoordinate(i) = y + p->estimatedSize().height();
-		y += p->estimatedSize().height();
+		y += p->estimatedSize().height()+props.gapSize();//gap
 	}
     }
     updateSceneRect();

--- a/src/View/ContinuousPageView.h
+++ b/src/View/ContinuousPageView.h
@@ -57,6 +57,7 @@ namespace QComicBook
         virtual void gotoPage(int n);
         virtual void scrollToTop();
         virtual void scrollToBottom();
+        virtual void setGapSize(int f);
         
     public:
         ContinuousPageView(QWidget *parent, int physicalPages, const ViewProperties& props);

--- a/src/ViewProperties.cpp
+++ b/src/ViewProperties.cpp
@@ -36,6 +36,7 @@ void ViewProperties::setFromSettings()
     m_data.mangaMode = cfg.japaneseMode();
     m_data.background = cfg.background();
     m_data.smoothScaling = cfg.smoothScaling();
+    m_data.gapSize = cfg.gapSize();
 }
 
 int ViewProperties::angle() const
@@ -140,4 +141,17 @@ bool ViewProperties::mangaMode() const
 const ViewPropertiesData& ViewProperties::getProperties() const
 {
     return m_data;
+}
+
+void ViewProperties::setGapSize(int f)
+{
+    if (m_data.gapSize != f)
+        {
+            m_data.gapSize = f;
+            emit changed();
+        }
+}
+int ViewProperties::gapSize() const
+{
+    return m_data.gapSize;
 }

--- a/src/ViewProperties.cpp
+++ b/src/ViewProperties.cpp
@@ -12,6 +12,7 @@
 
 #include "ViewProperties.h"
 #include "ComicBookSettings.h"
+#include "ComicBookDebug.h"
 
 using namespace QComicBook;
 
@@ -88,6 +89,7 @@ void ViewProperties::setPageNumbers(bool f)
     {
         m_data.pageNumbers = f;
         emit changed();
+        _DEBUG << "m_data. =" << m_data.gapSize ;
     }
 }
 
@@ -149,6 +151,7 @@ void ViewProperties::setGapSize(int f)
         {
             m_data.gapSize = f;
             emit changed();
+            _DEBUG << "m_data.gapSize =" << m_data.gapSize ;
         }
 }
 int ViewProperties::gapSize() const

--- a/src/ViewProperties.h
+++ b/src/ViewProperties.h
@@ -45,6 +45,8 @@ namespace QComicBook
         bool twoPagesMode() const;
         void setMangaMode(bool f);
         bool mangaMode() const;
+        void setGapSize(int f);
+        int gapSize() const;
         const ViewPropertiesData& getProperties() const;
 
     private:

--- a/src/ViewPropertiesData.h
+++ b/src/ViewPropertiesData.h
@@ -31,6 +31,7 @@ namespace QComicBook
         bool mangaMode;
         bool contScroll;
         bool smoothScaling;
+        int gapSize;
     };
 }
 


### PR DESCRIPTION
It is simple feature that add gap, configurable in size, between images for continuous view. I made this because I really like continuous view mode, which allow more smooth experience, but sometimes I got confused on page edge with frame order and simple gap or border would help with it, so here it is. Gap size of 0 allow retain old look.