### PR TITLE
Install app icon in XDG hicolor icon theme

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -24,6 +24,6 @@ SET(DATA_FILES bestfit.png
 	     qcomicbook-splash.png)
 
 #INSTALL(FILES ${DATA_FILES} DESTINATION share/${PACKAGE})
-INSTALL(FILES qcomicbook.png DESTINATION share/pixmaps)
+INSTALL(FILES qcomicbook.png DESTINATION share/icons/hicolor/48x48/apps)
 INSTALL(FILES qcomicbook.desktop DESTINATION share/applications)
 


### PR DESCRIPTION
Install the icon of the application in the hicolor XDG icon theme; this way it can be properly loaded by XDG menus in the currently set XDG icon theme, without looking in the legacy pixmaps location.